### PR TITLE
Add Yelp data provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "capstone-project",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,12 @@ var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
+// copy config defaults to config.json if it doesn't exist already
+var fs = require('fs');
+if (!fs.existsSync('config.json')) {
+  fs.copyFileSync('config-defaults.json', 'config.json', fs.constants.COPYFILE_EXCL)
+}
+
 var app = express(); // init express app
 
 // add websocket support

--- a/server/config-defaults.json
+++ b/server/config-defaults.json
@@ -1,0 +1,5 @@
+{
+    "apiKeys": {
+        "yelp": "INSERT-API-KEY-HERE-BEFORE-RUN"
+    }
+}

--- a/server/data_providers/yelp.js
+++ b/server/data_providers/yelp.js
@@ -60,6 +60,8 @@ class YelpDataProvider {
 	}
 
   #yelpBusinessAsActivity(business) {
+    let tags = business.categories.map(category => category.title);
+
     let activity = {
       "id": "yelp-" + business.id,
       "name": business.name,
@@ -68,7 +70,7 @@ class YelpDataProvider {
       "distance": business.distance,
       "description": "No description available",  // TODO: get a description from somewhere. Maybe need to have a separate API call
       "budget": [0.0, 9999.99],                   // TODO:  convert from yelp's $$$ notation to actual number range
-      "tags": [],                                 // TODO: OSM's tags don't seem to correspond to what we consider "tags"
+      "tags": tags,                                 // TODO: OSM's tags don't seem to correspond to what we consider "tags"
       "imageUrl": business.image_url,
       "externalLinks": {
         "yelp": business.url

--- a/server/data_providers/yelp.js
+++ b/server/data_providers/yelp.js
@@ -68,6 +68,11 @@ class YelpDataProvider {
 		return this.requests < RATE_LIMIT_DAILY;
 	}
 
+  /**
+   * This turns a single Yelp Business JSON object into a Conzensus Activity
+   * @param {Object} business Yelp Business object
+   * @returns {Activity} Conzensus Activity
+   */
   #yelpBusinessAsActivity(business) {
     let tags = business.categories.map(category => category.title);
 

--- a/server/data_providers/yelp.js
+++ b/server/data_providers/yelp.js
@@ -5,6 +5,14 @@ const config = require("../config.json");
 const RATE_LIMIT_DAILY = 5000;
 const ENDPOINT = "https://api.yelp.com/v3";
 
+// TODO: refine these!!! some active category stuff are actually indoors etc.
+// see https://docs.developer.yelp.com/docs/resources-categories
+const CATEGORY_TYPES = {
+  "food": ["restaurants", "food"],
+  "outdoor": ["active"],
+  "indoor": ["arts", "museums", "musicvenues", "shopping"]
+}
+
 /**
  * Data provider which abstracts away Yelp Fusion API calls.
  * 
@@ -32,7 +40,8 @@ class YelpDataProvider {
       radius: meters,
       limit: 50,
       sort_by: "best_match",
-      open_now: "true"
+      open_now: "true",
+      categories: CATEGORY_TYPES[activityType]
 		});
 		let queryUrl = `${ENDPOINT}/businesses/search?${yelpQuery}`;
 

--- a/server/data_providers/yelp.js
+++ b/server/data_providers/yelp.js
@@ -79,12 +79,12 @@ class YelpDataProvider {
     let activity = {
       "id": "yelp-" + business.id,
       "name": business.name,
-      "category": "temp", // TODO: FILL ME IN!!!
+      "category": tags[0], // TODO: Since could be multiple categories, should we convert Activity.category to array type?
       "coordinates": [business.coordinates.latitude, business.coordinates.longitude],
       "distance": business.distance,
       "description": "No description available",  // TODO: get a description from somewhere. Maybe need to have a separate API call
       "budget": [0.0, 9999.99],                   // TODO:  convert from yelp's $$$ notation to actual number range
-      "tags": tags,                                 // TODO: OSM's tags don't seem to correspond to what we consider "tags"
+      "tags": tags,
       "imageUrl": business.image_url,
       "externalLinks": {
         "yelp": business.url

--- a/server/tests/data_providers/yelp.js
+++ b/server/tests/data_providers/yelp.js
@@ -1,0 +1,21 @@
+let YelpDataProvider = require("../../data_providers/yelp");
+
+async function yelpProviderReturnsActivities() {
+  let provider = new YelpDataProvider();
+
+  let activities = await provider.getActivitiesInRadius(
+    "indoor",
+    1000,
+    47.66009172738974,
+    -122.31304749174053
+  );
+
+  if (activities.length <= 0) {
+    console.error("Failed test yelpProviderReturnsActivities(): Yelp data provider failed to return any Activities!");
+  } else {
+    console.log("Passed test yelpProviderReturnsActivities()")
+  }
+}
+
+// run tests
+yelpProviderReturnsActivities();


### PR DESCRIPTION
This PR adds the Yelp data provider. You will need to get an API key from https://www.yelp.com/developers/v3/manage_app (it's really easy, you get it immediately). When you run the server for the first, time `config-defaults.json` will get copied to `config.json` and you need to put your API key in the yelp API key slot and restart the server.

The Yelp data provider has the same interface as the OverpassDataProvider, so you should be able to just use it.

This PR closes #21.